### PR TITLE
fix: Move up the #_busy flag to fix the synchronization queue error. 

### DIFF
--- a/src/TaskRunner.ts
+++ b/src/TaskRunner.ts
@@ -123,6 +123,8 @@ export class TaskRunner<T = any> {
   #run() {
     if (this.#completed !== this.#total) {
       if (!this.#_paused && this.#running < this.#_concurrency) {
+        this.#_busy = true;
+        
         const difference = this.#_concurrency - this.#running;
 
         const tasks = this.#_pending.removeRange(0, difference) as Tasks<T>;
@@ -139,10 +141,9 @@ export class TaskRunner<T = any> {
             task,
           });
         });
-
-        this.#_busy = true;
       }
     } else {
+      this.#_busy = false;
       this.#_duration.end = Date.now();
       this.#_duration.total = Math.ceil(
         this.#_duration.end - this.#_duration.start
@@ -150,8 +151,6 @@ export class TaskRunner<T = any> {
 
       /* istanbul ignore next */
       this.#runHook(RunnerEvents.END);
-
-      this.#_busy = false;
     }
   }
 


### PR DESCRIPTION
```js
  #run() {
    if (this.#completed !== this.#total) {
      if (!this.#_paused && this.#running < this.#_concurrency) {
        const difference = this.#_concurrency - this.#running;

        const tasks = this.#_pending.removeRange(0, difference) as Tasks<T>;

        tasks.forEach((task) => {
          task.status = TaskStatus.RUNNING;

          this.#_running.add(task);

          task.run(this.#done(task)); // will call the #run and set #_busy at first

          /* istanbul ignore next */
          this.#runHook(RunnerEvents.RUN, {
            task,
          });
        });

        this.#_busy = true; // is too late
      }
.......
```
Move up the #_busy flag can fix the synchronization queue error. 