### PR TITLE
fix: move up the busy flag to enable starting synchronization queue

### DIFF
--- a/src/TaskRunner.ts
+++ b/src/TaskRunner.ts
@@ -127,6 +127,7 @@ export class TaskRunner<T = any> {
 
         const tasks = this.#_pending.removeRange(0, difference) as Tasks<T>;
 
+        this.#_busy = true;
         tasks.forEach((task) => {
           task.status = TaskStatus.RUNNING;
 
@@ -139,8 +140,6 @@ export class TaskRunner<T = any> {
             task,
           });
         });
-
-        this.#_busy = true;
       }
     } else {
       this.#_duration.end = Date.now();


### PR DESCRIPTION
```js
#run() {
    if (this.#completed !== this.#total) {
      if (!this.#_paused && this.#running < this.#_concurrency) {
        const difference = this.#_concurrency - this.#running;

        const tasks = this.#_pending.removeRange(0, difference) as Tasks<T>;

        tasks.forEach((task) => {
          task.status = TaskStatus.RUNNING;

          this.#_running.add(task);

          task.run(this.#done(task));       // will call the #run and set #_busy at first

          /* istanbul ignore next */
          this.#runHook(RunnerEvents.RUN, {
            task,
          });
        });

        this.#_busy = true;    // is too late
      }
// .......
```

Move up the `#_busy` flag can fix the synchronization queue error.

Fixes #56 